### PR TITLE
Use shared_ptr instead
 of  raw pointer

### DIFF
--- a/include/agent/Agent.h
+++ b/include/agent/Agent.h
@@ -26,8 +26,8 @@ public:
     const int getNumBehaviors() const;
     void addBehavior(const BehaviorPtr& new_behavior);
     void removeBehaviorAt(const unsigned int layer);
-    const Behavior* getBehaviorAt(const unsigned int layer) const;
-    const Behavior* getBehaviorByID(const unsigned int id) const;
+    const BehaviorPtr getBehaviorAt(const unsigned int layer) const;
+    const BehaviorPtr getBehaviorByID(const unsigned int id) const;
 };
 
 #endif

--- a/include/environment/Environment.h
+++ b/include/environment/Environment.h
@@ -23,7 +23,7 @@ public:
 
     void addSensor(const std::string& name, const SensorPtr& sensor);
 
-    const Sensor* getSensorByName(const std::string& name) const;
+    const SensorPtr getSensorByName(const std::string& name) const;
     const int getNumSensor() const;
 };
 #endif

--- a/src/agent/Agent.cpp
+++ b/src/agent/Agent.cpp
@@ -67,22 +67,22 @@ void Agent::removeBehaviorAt(unsigned int layer)
                     behaviors.end());
 }
 
-const Behavior* Agent::getBehaviorAt(const unsigned int layer) const
+const BehaviorPtr Agent::getBehaviorAt(const unsigned int layer) const
 {
     if(!isValidLayer(layer))
-        return NULL;
+        return BehaviorPtr();
 
-    return behaviors.at(layer).get();
+    return behaviors.at(layer);
 }
 
-const Behavior* Agent::getBehaviorByID(const unsigned int id) const
+const BehaviorPtr Agent::getBehaviorByID(const unsigned int id) const
 {
     int layer = convertFromIDtoLayer(id);
 
     if(layer == INVALID_LAYER)
-        return NULL;
+        return BehaviorPtr();
 
-    return behaviors.at(static_cast<unsigned int>(layer)).get();
+    return behaviors.at(static_cast<unsigned int>(layer));
 }
 
 const int Agent::convertFromIDtoLayer(unsigned int id) const

--- a/src/environment/Environment.cpp
+++ b/src/environment/Environment.cpp
@@ -51,11 +51,11 @@ const int Environment::getNumSensor() const
     return sensor_list.size();
 }
 
-const Sensor* Environment::getSensorByName(const std::string& name) const
+const SensorPtr Environment::getSensorByName(const std::string& name) const
 {
     SensorList::const_iterator it = sensor_list.find(name);
     if(it == sensor_list.end())
-        return NULL;
+        return SensorPtr();
 
-    return it->second.get();
+    return it->second;
 }

--- a/target.mk
+++ b/target.mk
@@ -28,6 +28,7 @@ INC_DIRS = \
 
 INCLUDE_DIRS = \
 	$(CPPUTEST_HOME)/include\
+	$(PROJECT_HOME_DIR)/tests\
 	${INC_DIRS}
 
 MOCKS_SRC_DIRS = \

--- a/tests/UtilAssert.h
+++ b/tests/UtilAssert.h
@@ -1,0 +1,29 @@
+#ifndef D_UTIL_ASSERT_H
+#define D_UTIL_ASSERT_H
+
+#include <boost/shared_ptr.hpp>
+#include "CppUTest/TestHarness.h"
+
+#define SHARED_PTRS_EQUAL(expect, actual) \
+    SHARED_PTRS_EQUAL_LOCATION(expect, actual, __FILE__, __LINE__)
+
+#define CHECK_SHARED_PTR_NULL(actual) \
+    CHECK_SHARED_PTR_NULL_LOCATION(actual, __FILE__, __LINE__)
+
+template <class T_Expect, class T_Actual>
+void SHARED_PTRS_EQUAL_LOCATION(boost::shared_ptr<T_Expect> expect,
+                                boost::shared_ptr<T_Actual>  actual,
+                                const char *fileName, int lineNumber)
+{
+    POINTERS_EQUAL_LOCATION(expect.get(), actual.get(), fileName, lineNumber);
+}
+
+template <class T_Actual>
+void CHECK_SHARED_PTR_NULL_LOCATION(boost::shared_ptr<T_Actual>  actual,
+                                    const char *fileName, int lineNumber)
+{
+    POINTERS_EQUAL_LOCATION(NULL, actual.get(), fileName, lineNumber);
+}
+
+
+#endif

--- a/tests/agent/AgentTest.cpp
+++ b/tests/agent/AgentTest.cpp
@@ -1,4 +1,5 @@
 #include "CppUTest/TestHarness.h"
+#include "UtilAssert.h"
 
 #include "Agent.h"
 #include "SpyBehavior.h"
@@ -85,7 +86,6 @@ TEST_GROUP(Agent)
         for(unsigned int i = 0; i < behaviors->size(); i++)
             CHECK_EQUAL(false, behaviors->at(i)->performed());
     }
-
 };
 
 TEST(Agent, Create)
@@ -118,7 +118,7 @@ TEST(Agent, AttachNullLayer)
     SpyBehaviorPtr nullBehavior( static_cast<SpyBehavior *>(NULL) );
     agent->addBehavior(nullBehavior);
     LONGS_EQUAL(0, agent->getNumBehaviors());
-    POINTERS_EQUAL(NULL, agent->getBehaviorAt(0));
+    CHECK_SHARED_PTR_NULL(agent->getBehaviorAt(0));
 }
 
 TEST(Agent, SingleBehaviorStep)
@@ -196,16 +196,14 @@ TEST(Agent, GetWithBehaviorID)
     createBehaviors(id_list, 2, &behaviors);
     setBehaviorsToAgent(&behaviors);
 
-    POINTERS_EQUAL(behaviors.at(dummy_layer_01).get(),
-                   agent->getBehaviorByID(dummy_id_01));
-    POINTERS_EQUAL(behaviors.at(dummy_layer_02).get(),
-                   agent->getBehaviorByID(dummy_id_02));
+    SHARED_PTRS_EQUAL(behaviors.at(dummy_layer_01), agent->getBehaviorByID(dummy_id_01));
+    SHARED_PTRS_EQUAL(behaviors.at(dummy_layer_02), agent->getBehaviorByID(dummy_id_02));
 }
 
 TEST(Agent, GetNotAttachedBehavior)
 {
-    POINTERS_EQUAL(NULL, agent->getBehaviorAt(0));
-    POINTERS_EQUAL(NULL, agent->getBehaviorByID(dummy_id_01));
+    CHECK_SHARED_PTR_NULL(agent->getBehaviorAt(0));
+    CHECK_SHARED_PTR_NULL(agent->getBehaviorByID(dummy_id_01));
 }
 
 TEST(Agent, DisableToAttachSameID)
@@ -214,8 +212,8 @@ TEST(Agent, DisableToAttachSameID)
     SpyBehaviorPtr second_behavior = createBehaviorPtr(dummy_id_01);
 
     agent->addBehavior(first_behavior);
-    POINTERS_EQUAL(first_behavior.get(), agent->getBehaviorByID(dummy_id_01));
+    SHARED_PTRS_EQUAL(first_behavior, agent->getBehaviorByID(dummy_id_01));
 
     agent->addBehavior(second_behavior);
-    POINTERS_EQUAL(second_behavior.get(), agent->getBehaviorByID(dummy_id_01));
+    SHARED_PTRS_EQUAL(second_behavior, agent->getBehaviorByID(dummy_id_01));
 }

--- a/tests/environment/EnvironmentTest.cpp
+++ b/tests/environment/EnvironmentTest.cpp
@@ -1,5 +1,6 @@
 #include "CppUTest/TestHarness.h"
 #include "CppUTestExt/MockSupport.h"
+#include "UtilAssert.h"
 
 #include "Environment.h"
 #include "MockSensor.h"
@@ -53,7 +54,7 @@ TEST_GROUP(Environment)
         LONGS_EQUAL(sensors->size(), env->getNumSensor());
 
         for(unsigned int i = 0; i < sensors->size(); i++)
-            POINTERS_EQUAL(sensors->at(i).get(), env->getSensorByName(names[i]));
+            SHARED_PTRS_EQUAL(sensors->at(i), env->getSensorByName(names[i]));
     }
 
     void expectOneCallOfInitIn(const MockSensorPtr& sensor)
@@ -99,7 +100,7 @@ TEST(Environment, AddMultipleSensor)
 TEST(Environment, NoSensorInEnvironment)
 {
     LONGS_EQUAL(0, env->getNumSensor());
-    POINTERS_EQUAL(NULL, env->getSensorByName("not_exist_sensor"));
+    CHECK_SHARED_PTR_NULL(env->getSensorByName("not_exist_sensor"));
 }
 
 TEST(Environment, AddNullSensor)
@@ -107,7 +108,7 @@ TEST(Environment, AddNullSensor)
     MockSensorPtr null_sensor( static_cast<MockSensor*>(NULL) );
     env->addSensor(dummy_name_01, null_sensor);
     LONGS_EQUAL(0, env->getNumSensor());
-    POINTERS_EQUAL(NULL, env->getSensorByName(dummy_name_01));
+    CHECK_SHARED_PTR_NULL(env->getSensorByName(dummy_name_01));
 }
 
 TEST(Environment, SingleSensorControl)


### PR DESCRIPTION
生ポインタを戻り値にしている部分で、shared_ptrを利用するようにする。
場所によっては、weak_ptrを使うこと。
