### PR TITLE
fix behavior construcor

### DIFF
--- a/include/agent/Behavior.h
+++ b/include/agent/Behavior.h
@@ -7,6 +7,11 @@ class Behavior {
 protected:
     unsigned int id;
 public:
+    Behavior(const unsigned int behavior_id)
+    {
+        this->id = behavior_id;
+    }
+
     virtual ~Behavior(){}
 
     virtual void init() = 0;

--- a/mocks/agent/SpyBehavior.cpp
+++ b/mocks/agent/SpyBehavior.cpp
@@ -1,8 +1,7 @@
 #include "SpyBehavior.h"
 
-SpyBehavior::SpyBehavior(const unsigned int id)
+SpyBehavior::SpyBehavior(const unsigned int id) : Behavior(id)
 {
-    this->id = id;
     this->activation = true;
     this->init_state = false;
     this->sensing_state = false;


### PR DESCRIPTION
Behaviorクラスは必ずIDをセットしなければならないが、
デフォルトコンストラクタしかないので、IDのセットが明示的でない。
なので、IDを渡すコンストラクタを追加。
