### PR TITLE
fix not to send coverage with clang

### DIFF
--- a/scripts/coveralls.sh
+++ b/scripts/coveralls.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # send coverage report to coveralls
 
+if [ "$CC" = "clang" ]; then
+	exit 0
+fi
 
 if [ "$BUILD_TARGET" = "test" ]; then
 	coveralls --root gcov


### PR DESCRIPTION
clang + gcovによるカバレッジ計測結果に異常があるため、
当面clangでのビルドではカバレッジを測定しないようにする。
