### PR TITLE
Fix to guard with thread invalid call

### DIFF
--- a/src/util/Thread.cpp
+++ b/src/util/Thread.cpp
@@ -41,6 +41,10 @@ bool Thread::init()
 
 bool Thread::start()
 {
+    /* Activeのとき無効 */
+    if(isActive())
+        return false;
+
     /* 未初期化時無効 */
     if(!isReady())
         return false;

--- a/src/util/Thread.cpp
+++ b/src/util/Thread.cpp
@@ -100,6 +100,8 @@ void Thread::requestStarting()
     if(!isReady())
         return;
 
+    lock lk(message_guard);
+    this->end_flag = false;
     this->main_thread = ThreadPtr(new boost::thread(&Thread::main, this));
 }
 

--- a/tests/util/ThreadTest.cpp
+++ b/tests/util/ThreadTest.cpp
@@ -80,6 +80,18 @@ TEST(Thread, StartWithoutInit)
     CHECK_EQUAL(false, runner->performed());
 }
 
+TEST(Thread, StartUntilActive)
+{
+    CHECK_EQUAL(true, thread->init());
+    CHECK_EQUAL(true, thread->isReady());
+
+    CHECK_EQUAL(true, thread->start());
+    CHECK_EQUAL(true, thread->isActive());
+
+    CHECK_EQUAL(false, thread->start());
+    CHECK_EQUAL(true, thread->isActive());
+}
+
 TEST(Thread, StopWithoutStart)
 {
     CHECK_EQUAL(true, thread->init());

--- a/tests/util/ThreadTest.cpp
+++ b/tests/util/ThreadTest.cpp
@@ -129,3 +129,16 @@ TEST(Thread, InitAfterStarted)
 
     CHECK_EQUAL(true, thread->stop());
 }
+
+TEST(Thread, Start2ndTime)
+{
+    CHECK_EQUAL(true, thread->init());
+    CHECK_EQUAL(true, thread->start());
+    CHECK_EQUAL(true, thread->stop());
+
+    CHECK_EQUAL(true, thread->start());
+    CHECK_EQUAL(true, thread->isActive());
+
+    CHECK_EQUAL(true, thread->stop());
+    CHECK_EQUAL(false, thread->isActive());
+}


### PR DESCRIPTION
`Thread` のAPIで、ガードできていないケースがあったので修正
- Active時のThread#start()
- Thread#stop() 後の Thread#start()
