### PR TITLE
Fix build failure with clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test: CppUTest CppUTestExt
 	make -f scripts/MakefileCppUTest.mk
 
 gcov: CppUTest CppUTestExt clean
-	make -f scripts/MakefileCppUTest.mk gcov
+	make -f scripts/MakefileCppUTest.mk CPPUTEST_USE_GCOV=Y gcov
 
 cleanTest:
 	make -i -f scripts/MakefileCppUTest.mk clean

--- a/scripts/MakefileCppUTest.mk
+++ b/scripts/MakefileCppUTest.mk
@@ -13,7 +13,6 @@ CPPUTEST_WARNINGFLAGS = -Wall -W -Werror -pedantic-errors\
 CPPUTEST_CXXFLAGS += -include tests/PreIncludeFiles.h
 LD_LIBRARIES = -lpthread -lboost_thread-mt -lboost_system-mt
 
-CPPUTEST_USE_GCOV = Y
 CPPUTEST_USE_EXTENSIONS = Y
 
 include $(CPPUTEST_HOME)/build/MakefileWorker.mk

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -3,12 +3,12 @@
 
 if [ "$BUILD_TARGET" = "test" ]; then
     if [ "$CC" = "gcc" ]; then
-        make gcov;
+        make gcov || exit 1
     else
-        make test;
+        make test || exit 1
     fi
 fi
 
 if [ "$BUILD_TARGET" = "release" ]; then
-	make release
+	make release || exit 1
 fi

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -2,7 +2,11 @@
 # build script for Travis CI
 
 if [ "$BUILD_TARGET" = "test" ]; then
-	make gcov
+    if [ "$CC" = "gcc" ]; then
+        make gcov;
+    else
+        make test;
+    fi
 fi
 
 if [ "$BUILD_TARGET" = "release" ]; then


### PR DESCRIPTION
#### travis ciにおけるclangのbuildエラーを修正する

travis ciの利用するclangのバージョンが3.3になった関係で、
coverageオプションをつけた状態だと、リンクに失敗するようになっていた。

現状、clangのテストでは、カバレッジを計測していないため、clangでのテスト時は、
coverageオプションを付けないよう修正

また、ビルド失敗にもかかわらず、travis ciが認識できていなかった不具合を修正。
（失敗したとき、即時 `exit 1` するよう修正）
