### PR TITLE
fix to move config to target.mk

### DIFF
--- a/scripts/MakefileCppUTest.mk
+++ b/scripts/MakefileCppUTest.mk
@@ -7,9 +7,8 @@ SILENCE = @
 include target.mk
 
 #---- Setting ----#
-CPPUTEST_WARNINGFLAGS = -Wall -W -Werror -pedantic-errors\
-                        -Wcast-qual -Wcast-align -Wwrite-strings\
-                        -Wconversion -Wfloat-equal -Wpointer-arith
+CPPUTEST_WARNINGFLAGS = $(CPPWARNINGFLAGS)
+
 CPPUTEST_CXXFLAGS += -include tests/PreIncludeFiles.h
 LD_LIBRARIES = -lpthread -lboost_thread-mt -lboost_system-mt
 

--- a/scripts/MakefileCppUTest.mk
+++ b/scripts/MakefileCppUTest.mk
@@ -10,7 +10,8 @@ include target.mk
 CPPUTEST_WARNINGFLAGS = $(CPPWARNINGFLAGS)
 
 CPPUTEST_CXXFLAGS += -include tests/PreIncludeFiles.h
-LD_LIBRARIES = -lpthread -lboost_thread-mt -lboost_system-mt
+CPPUTEST_LDFLAGS += $(LIBRARY_DIRS)
+LD_LIBRARIES = $(LIBRARY_FILES)
 
 CPPUTEST_USE_EXTENSIONS = Y
 

--- a/scripts/MakefileRelease.mk
+++ b/scripts/MakefileRelease.mk
@@ -28,7 +28,7 @@ SRCS += $(call get_src_from_dir_list, $(SRC_DIRS)) $(SRC_FILES)
 OBJS = $(call src_to_o,$(SRCS))
 
 CPPFLAGS += $(INCLUDES) $(CPPWARNINGFLAGS)
-LDFLAGS  = -lboost_thread-mt -lboost_system-mt
+LDFLAGS  = $(LIBRARY_FILES)
 
 all: $(TARGET)
 

--- a/scripts/MakefileRelease.mk
+++ b/scripts/MakefileRelease.mk
@@ -27,10 +27,6 @@ INCLUDES += $(foreach dir, $(INCLUDES_DIRS_EXPANDED), -I$(dir))
 SRCS += $(call get_src_from_dir_list, $(SRC_DIRS)) $(SRC_FILES)
 OBJS = $(call src_to_o,$(SRCS))
 
-CPPWARNINGFLAGS +=	-Wall -W -Werror -pedantic-errors\
-					-Wcast-qual -Wcast-align -Wwrite-strings\
-					-Wconversion -Wfloat-equal -Wpointer-arith
-
 CPPFLAGS += $(INCLUDES) $(CPPWARNINGFLAGS)
 LDFLAGS  = -lboost_thread-mt -lboost_system-mt
 

--- a/target.mk
+++ b/target.mk
@@ -36,3 +36,10 @@ MOCKS_SRC_DIRS = \
 	$(PROJECT_HOME_DIR)/mocks/agent\
 	$(PROJECT_HOME_DIR)/mocks/environment\
 	$(PROJECT_HOME_DIR)/mocks/util\
+
+#--- Configs ---#
+
+CPPWARNINGFLAGS = \
+	-Wall -W -Werror -pedantic-errors\
+	-Wcast-qual -Wcast-align -Wwrite-strings\
+	-Wconversion -Wfloat-equal -Wpointer-arith\

--- a/target.mk
+++ b/target.mk
@@ -37,6 +37,12 @@ MOCKS_SRC_DIRS = \
 	$(PROJECT_HOME_DIR)/mocks/environment\
 	$(PROJECT_HOME_DIR)/mocks/util\
 
+#--- Librarys ---#
+LIBRARY_DIRS = \
+
+LIBRARY_FILES = \
+	-lboost_thread-mt -lboost_system-mt
+
 #--- Configs ---#
 
 CPPWARNINGFLAGS = \


### PR DESCRIPTION
リリースビルド・テストビルド時で、それぞれ共通となっている設定を、target.mkに移動させる
- waringの設定
- 外部ライブラリの設定
